### PR TITLE
Fix inserting chunks concurrently

### DIFF
--- a/modules/core/src/main/scala/binny/InsertChunkResult.scala
+++ b/modules/core/src/main/scala/binny/InsertChunkResult.scala
@@ -13,7 +13,41 @@ object InsertChunkResult {
   final case class InvalidChunkIndex(msg: String) extends InsertChunkResult
 
   def complete: InsertChunkResult = Complete
+
   def incomplete: InsertChunkResult = Incomplete
+
   def invalidChunkSize(msg: String): InsertChunkResult = InvalidChunkSize(msg)
+
   def invalidChunkIndex(msg: String): InsertChunkResult = InvalidChunkIndex(msg)
+
+  private[binny] def validateChunk(
+      chunkDef: ChunkDef,
+      chunkSize: Int,
+      actualSize: Int
+  ): Option[InsertChunkResult] = {
+    val ch = chunkDef.fold(identity, _.toTotal(chunkSize))
+    val isLastChunk = ch.index == ch.total - 1
+    if (ch.index < 0 || ch.index >= ch.total)
+      Some(
+        InsertChunkResult
+          .invalidChunkIndex(
+            s"Index ${ch.index} must not be negative or >= total chunks ${ch.total}"
+          )
+      )
+    else if (isLastChunk && actualSize > chunkSize)
+      Some(
+        InsertChunkResult
+          .invalidChunkSize(
+            s"Chunk exceeds chunk size: $actualSize > $chunkSize"
+          )
+      )
+    else if (!isLastChunk && actualSize != chunkSize)
+      Some(
+        InsertChunkResult
+          .invalidChunkSize(
+            s"Chunk ($actualSize) does not match chunk size ($chunkSize)"
+          )
+      )
+    else None
+  }
 }

--- a/modules/microsite/src/main/resources/microsite/js/fathom.js
+++ b/modules/microsite/src/main/resources/microsite/js/fathom.js
@@ -1,4 +1,4 @@
-// Fathom - simple website analytics - https://github.com/usefathom/fathom -->
+// Fathom - simple website analytics - https://github.com/usefathom/fathom
 (function(f, a, t, h, o, m){
   a[h]=a[h]||function(){
     (a[h].q=a[h].q||[]).push(arguments)
@@ -8,5 +8,5 @@
   o.async=1; o.src=t; o.id='fathom-script';
   m.parentNode.insertBefore(o,m)
 })(document, window, '//webstats.daheim.site/tracker.js', 'fathom');
-fathom('set', 'siteId', '--<your-id>--');
+fathom('set', 'siteId', 'MMYRN');
 fathom('trackPageview');


### PR DESCRIPTION
Two or more threads may insert "the last" chunk concurrently. Then
both must yield a "complete" result. The result must be obtained after
writing the chunk, otherwise a "complete" result will never be
obtained (if all chunks are stored in parallel). Attributes could not
be updated concurrently.