### PR TITLE
Update fs2 and fix a bug that was not exposed with fs2 3.2.7

### DIFF
--- a/modules/core/src/main/scala/binny/BinaryAttributes.scala
+++ b/modules/core/src/main/scala/binny/BinaryAttributes.scala
@@ -62,8 +62,10 @@ object BinaryAttributes {
       ct: Option[SimpleContentType]
   ) {
     def update(detect: ContentTypeDetect, hint: Hint)(c: Chunk[Byte]): State = {
-      md.update(c.toArraySlice.values)
-      new State(md, len + c.size, ct.orElse(Some(detect.detect(c.toByteVector, hint))))
+      val bytes = c.toArraySlice
+      val bv = ByteVector.view(bytes.values, bytes.offset, bytes.size)
+      md.update(bytes.values, bytes.offset, bytes.size)
+      new State(md, len + c.size, ct.orElse(Some(detect.detect(bv, hint))))
     }
 
     def update(detect: ContentTypeDetect, hint: Hint, c: Array[Byte]): State = {

--- a/modules/jdbc/src/main/scala/binny/jdbc/impl/DbRunApi.scala
+++ b/modules/jdbc/src/main/scala/binny/jdbc/impl/DbRunApi.scala
@@ -152,7 +152,8 @@ final class DbRunApi[F[_]: Sync](table: String, logger: Logger[F]) {
         ps.setString(1, id.id)
         ps.setInt(2, index)
         ps.setInt(3, bytes.size)
-        ps.setBinaryStream(4, new ByteArrayInputStream(bytes.toArraySlice.values))
+        val bs = bytes.toArraySlice
+        ps.setBinaryStream(4, new ByteArrayInputStream(bs.values, bs.offset, bs.size))
       }
 
   def insertAllData(

--- a/modules/pglo/src/main/scala/binny/pglo/impl/PgApi.scala
+++ b/modules/pglo/src/main/scala/binny/pglo/impl/PgApi.scala
@@ -86,7 +86,8 @@ final class PgApi[F[_]: Sync](table: String, logger: Logger[F]) {
             .evalMap(chunk =>
               Sync[F]
                 .blocking {
-                  obj.write(chunk.toArraySlice.values)
+                  val bs = chunk.toArraySlice
+                  obj.write(bs.values, bs.offset, bs.size)
                   chunk.size
                 }
             )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val fs2Version = "3.2.7"
+  val fs2Version = "3.2.8"
   val h2Version = "2.1.214"
   val munitVersion = "0.7.29"
   val munitCatsEffectVersion = "1.0.7"


### PR DESCRIPTION
The bug was incorrectly accessing byte arrays of chunks. With fs2
3.2.7 this was not observed, but with 3.2.8 it now is.