### PR TITLE
Avoid unsafeReadInputStream

### DIFF
--- a/modules/core/src/main/scala/binny/SimpleContentType.scala
+++ b/modules/core/src/main/scala/binny/SimpleContentType.scala
@@ -18,11 +18,17 @@ final class SimpleContentType private (val contentType: String) extends AnyVal {
 }
 
 object SimpleContentType {
-  val octetStream: SimpleContentType =
-    new SimpleContentType("application/octet-stream")
+  def application(subtype: String): SimpleContentType =
+    SimpleContentType(s"application/$subtype")
 
-  val textPlain: SimpleContentType =
-    new SimpleContentType("text/plain")
+  def text(subtype: String): SimpleContentType =
+    SimpleContentType(s"text/$subtype")
+
+  def image(subtype: String): SimpleContentType =
+    SimpleContentType(s"image/$subtype")
+
+  val octetStream: SimpleContentType = application("octet-stream")
+  val textPlain: SimpleContentType = text("plain")
 
   def apply(ct: String): SimpleContentType =
     if (ct.trim.isEmpty) octetStream

--- a/modules/core/src/test/scala/binny/ExampleData.scala
+++ b/modules/core/src/test/scala/binny/ExampleData.scala
@@ -21,6 +21,15 @@ object ExampleData {
       64 * 1024
     )
 
+  val logoPngAttr: BinaryAttributes =
+    BinaryAttributes(
+      ByteVector.fromValidHex(
+        "9dcc754fc5dd55f94431252f92348fc5ed76ad04133824dc08a7b4ec067b69cf"
+      ),
+      SimpleContentType.image("png"),
+      113186L
+    )
+
   val file2MAttr: BinaryAttributes =
     BinaryAttributes(
       ByteVector.fromValidHex(
@@ -48,6 +57,5 @@ object ExampleData {
 
     def readUtf8String =
       self.through(fs2.text.utf8.decode).compile.string
-
   }
 }

--- a/modules/minio/src/main/scala/binny/minio/Minio.scala
+++ b/modules/minio/src/main/scala/binny/minio/Minio.scala
@@ -208,7 +208,7 @@ final private[minio] class Minio[F[_]: Async](client: MinioAsyncClient) {
   def getObjectAsStream(key: S3Key, chunkSize: Int, range: ByteRange): Binary[F] = {
     val input = getObject(key, range).map(a => a: InputStream)
     fs2.io
-      .unsafeReadInputStream(input, chunkSize, closeAfterUse = true)
+      .readInputStream(input, chunkSize, closeAfterUse = true)
       .mapChunks(c => Chunk.byteVector(c.toByteVector))
   }
 
@@ -223,7 +223,7 @@ final private[minio] class Minio[F[_]: Async](client: MinioAsyncClient) {
       .redeemWith(decodeNotFoundAs(Option.empty[GetObjectResponse]), _.some.pure[F])
       .map(_.map { resp =>
         fs2.io
-          .unsafeReadInputStream(
+          .readInputStream(
             (resp: InputStream).pure[F],
             chunkSize,
             closeAfterUse = true

--- a/modules/minio/src/test/scala/binny/minio/MinioBinaryStoreTest.scala
+++ b/modules/minio/src/test/scala/binny/minio/MinioBinaryStoreTest.scala
@@ -9,7 +9,7 @@ class MinioBinaryStoreTest
 
   java.util.logging.Logger
     .getLogger(classOf[okhttp3.OkHttpClient].getName)
-    .setLevel(java.util.logging.Level.FINE);
+    .setLevel(java.util.logging.Level.FINE)
 
   val testContext: Fixture[TestContext[MinioBinaryStore[IO]]] =
     ResourceSuiteLocalFixture(


### PR DESCRIPTION
While using this is usually ok, it can lead to unexpected results when consuming the returned stream in specific ways, i.e. when using a collection builder via `.to(CollectionType)`. binny must not be affected by these measures, since it provides a facade to multiple storages.